### PR TITLE
[FormController] Ignore virtual fields for computed values

### DIFF
--- a/packages/lib/__tests__/formMeta.tsx
+++ b/packages/lib/__tests__/formMeta.tsx
@@ -96,6 +96,30 @@ describe('Form meta', async () => {
 
       expect(fieldDriver.get.meta('form:isDirty')).toBe('false');
     });
+
+    it('should ignore unmounted fields when calculating form isDirty', () => {
+      const TestComponent = ({hideField = false}) => (
+        <TestForm>
+          <Field defaultValue={''} name={TestForm.FIELD_ONE_NAME} adapter={InputAdapter} />
+          {!hideField && (
+            <Field defaultValue={''} name={TestForm.FIELD_TWO_NAME} adapter={InputAdapter} persist={true} />
+          )}
+        </TestForm>
+      );
+
+      const wrapper = mount(<TestComponent />);
+      const fieldDriver = createInputAdapterDriver({wrapper, dataHook: TestForm.FIELD_ONE_NAME});
+      const secondFieldDriver = createInputAdapterDriver({wrapper, dataHook: TestForm.FIELD_TWO_NAME});
+
+      expect(fieldDriver.get.meta('form:isDirty')).toBe('false');
+
+      secondFieldDriver.when.change('batman');
+
+      expect(fieldDriver.get.meta('form:isDirty')).toBe('true');
+
+      wrapper.setProps({hideField: true});
+      expect(fieldDriver.get.meta('form:isDirty')).toBe('false');
+    });
   });
 
   it('submitCount', () => {

--- a/packages/lib/src/FormController/FormController.ts
+++ b/packages/lib/src/FormController/FormController.ts
@@ -56,8 +56,8 @@ export interface FormMeta {
 }
 
 export interface SubmitResult {
-  errors: FormValidationErrors,
-  values: FormValues,
+  errors: FormValidationErrors;
+  values: FormValues;
 }
 
 export interface FormAPI {
@@ -318,14 +318,14 @@ export class FormController {
   @computed
   get isTouched(): boolean {
     const fieldValues = Array.from(this.fields.values());
-    return fieldValues.some((field: FormField) => field.meta.isTouched);
+    return fieldValues.some((field: FormField) => !!field.instance && field.meta.isTouched);
   }
 
   //are any of the fields have value different from initial
   @computed
   get isDirty(): boolean {
     const fieldValues = Array.from(this.fields.values());
-    return fieldValues.some((field: FormField) => field.meta.isDirty);
+    return fieldValues.some((field: FormField) => !!field.instance && field.meta.isDirty);
   }
 
   //all registered form fields, new field is being added when Field constructor is called

--- a/packages/lib/src/FormController/FormController.ts
+++ b/packages/lib/src/FormController/FormController.ts
@@ -318,14 +318,14 @@ export class FormController {
   @computed
   get isTouched(): boolean {
     const fieldValues = Array.from(this.fields.values());
-    return fieldValues.some((field: FormField) => !!field.instance && field.meta.isTouched);
+    return fieldValues.some((field: FormField) => field.instance !== null && field.meta.isTouched);
   }
 
   //are any of the fields have value different from initial
   @computed
   get isDirty(): boolean {
     const fieldValues = Array.from(this.fields.values());
-    return fieldValues.some((field: FormField) => !!field.instance && field.meta.isDirty);
+    return fieldValues.some((field: FormField) => field.instance !== null && field.meta.isDirty);
   }
 
   //all registered form fields, new field is being added when Field constructor is called
@@ -464,6 +464,6 @@ export class FormController {
       this.options.onSubmitAfter(errors, values, submitEvent);
     }
 
-    return {errors, values}
+    return {errors, values};
   };
 }


### PR DESCRIPTION
Sometimes form hide/replace some fields. We need to ignore them, so form API will work as expected