### PR TITLE
feat: add field-level disabled state

### DIFF
--- a/packages/lib/src/Field/Field.types.ts
+++ b/packages/lib/src/Field/Field.types.ts
@@ -9,6 +9,7 @@ export type OnValidateFunction<T = any> =
 export type FieldState = {
   initialValue: any;
   isDirty: boolean;
+  isDisabled: boolean;
   isTouched: boolean;
   isChanged: boolean;
   isActive: boolean;
@@ -39,6 +40,7 @@ export type OnEqualityCheckFunction<T = any> = (newValue: T, oldValue: T) => boo
 export type FieldCommonProps<T = any> = {
   name: string;
   defaultValue?: T;
+  isDisabled?: boolean;
   onValidate?: OnValidateFunction<T>;
   onFormat?: OnFormatFunction<T>;
   onEqualityCheck?: OnEqualityCheckFunction<T>;

--- a/packages/lib/src/FormControllerClass/FormControllerClass.ts
+++ b/packages/lib/src/FormControllerClass/FormControllerClass.ts
@@ -159,6 +159,7 @@ export class FormControllerClass {
           isMounted: false,
           isRegistered: false,
           isDirty: false,
+          isDisabled: false,
         },
       };
 
@@ -175,7 +176,7 @@ export class FormControllerClass {
   // used for first time field creation
   protected initializeVirtualField = (props: FieldProps) => {
     runInAction(() => {
-      const {name, onEqualityCheck, persist = false} = props;
+      const {name, onEqualityCheck, isDisabled, persist = false} = props;
       const field = this.fields.get(name)!;
 
       const initialValue = get(this.options.initialValues, name) ?? props.defaultValue;
@@ -190,6 +191,7 @@ export class FormControllerClass {
       assign(field.fieldState, {
         initialValue,
         ...(onEqualityCheck ? {onEqualityCheck} : {}),
+        ...(isDisabled !== undefined ? {isDisabled} : {}),
       });
 
       this.updateAPIValues(name, initialValue);
@@ -275,6 +277,7 @@ export class FormControllerClass {
           this.reset(values ?? this.options.initialValues ?? {});
         },
         setFieldValue: this.setFieldValue,
+        setFieldDisabled: this.setFieldDisabled,
         validate: this.validate,
         validateField: this.validateField,
         getField: (fieldName) => this.fields.get(fieldName),
@@ -361,6 +364,14 @@ export class FormControllerClass {
       }
 
       field.fieldState.isActive = isActive;
+    });
+  };
+
+  protected setFieldDisabled: FormApi['setFieldDisabled'] = (fieldName, isDisabled) => {
+    runInAction(() => {
+      this.createFieldIfDoesNotExist(fieldName);
+      const field = this.fields.get(fieldName)!;
+      field.fieldState.isDisabled = isDisabled;
     });
   };
 

--- a/packages/lib/src/FormControllerClass/FormControllerClass.types.ts
+++ b/packages/lib/src/FormControllerClass/FormControllerClass.types.ts
@@ -32,6 +32,7 @@ export type FieldState = {
   isActive: boolean;
   isValidating: boolean;
   isDirty: boolean;
+  isDisabled: boolean;
   isMounted: boolean;
   isRegistered: boolean;
 };
@@ -66,6 +67,7 @@ export type FormApi = {
   getField: (fieldName: string) => FormField | undefined;
   validateField: (fieldName: string) => any;
   setFieldValue: (fieldName: string, value: any) => void;
+  setFieldDisabled: (fieldName: string, isDisabled: boolean) => void;
   getFields: () => Record<string, FormField>;
   // controller
   controller: {

--- a/packages/lib/src/__tests__/specs/fieldState.spec.tsx
+++ b/packages/lib/src/__tests__/specs/fieldState.spec.tsx
@@ -99,6 +99,46 @@ describe('Field state', () => {
     expect(fieldDriver.get.fieldState('isChanged')).toBe('true');
   });
 
+  it('isDisabled - defaults to false', () => {
+    const wrapper = render(<TestForm />).container;
+    const fieldDriver = createInputDriver({wrapper, dataHook: TestForm.FIELD_ONE_NAME});
+
+    expect(fieldDriver.get.fieldState('isDisabled')).toBe('false');
+  });
+
+  it('isDisabled - set via Field prop', () => {
+    const wrapper = render(
+      <TestForm>
+        <Field name={TestForm.FIELD_ONE_NAME} isDisabled={true}>
+          <Input />
+        </Field>
+      </TestForm>,
+    ).container;
+    const fieldDriver = createInputDriver({wrapper, dataHook: TestForm.FIELD_ONE_NAME});
+
+    expect(fieldDriver.get.fieldState('isDisabled')).toBe('true');
+  });
+
+  it('isDisabled - set via API', () => {
+    const formController = createFormController({});
+    const wrapper = render(<TestForm controller={formController} />).container;
+    const fieldDriver = createInputDriver({wrapper, dataHook: TestForm.FIELD_ONE_NAME});
+
+    expect(fieldDriver.get.fieldState('isDisabled')).toBe('false');
+
+    act(() => {
+      formController.API.setFieldDisabled(TestForm.FIELD_ONE_NAME, true);
+    });
+
+    expect(fieldDriver.get.fieldState('isDisabled')).toBe('true');
+
+    act(() => {
+      formController.API.setFieldDisabled(TestForm.FIELD_ONE_NAME, false);
+    });
+
+    expect(fieldDriver.get.fieldState('isDisabled')).toBe('false');
+  });
+
   it('isValidating', async () => {
     const controller = createFormController({});
 


### PR DESCRIPTION
## Summary

Adds `isDisabled` to field state, following the same pattern as `isTouched`, `isDirty`, `isActive`, and other boolean field states.

### API

- **Programmatic**: `formController.API.setFieldDisabled(fieldName, isDisabled)` 
- **Declarative**: `<Field isDisabled={true}>` prop
- **Read**: `field.fieldState.isDisabled` in field components

### Changes

- `FieldState` types (both internal and public): added `isDisabled: boolean`
- `FieldCommonProps`: added optional `isDisabled?: boolean` prop
- `FormControllerClass`: new `setFieldDisabled` method, initialized to `false`, read from props
- `FormApi`: exposed `setFieldDisabled`
- `useRegisterField`: no changes needed — `isDisabled` flows through the existing `...rest` destructure
- Tests: 3 new specs (default false, set via prop, set via API)

### Motivation

Enables form-controller-driven disabled state without requiring external React context or URL param checks in field components. This is needed in wix-payments-account-management where prefilled form fields need to be disabled — currently solved with a React context that bypasses the form layer.

## Test plan

- [ ] `isDisabled` defaults to `false` for all fields
- [ ] `<Field isDisabled={true}>` sets `fieldState.isDisabled` to `true`
- [ ] `formController.API.setFieldDisabled(name, true/false)` toggles the state
- [ ] `reset()` does NOT reset `isDisabled` (it's a UI concern, not data)
- [ ] Existing tests pass unchanged